### PR TITLE
Remove obsolete AZUREJOBS_EXTENSION_VERSION App Setting

### DIFF
--- a/AzureFunctionDeployExample/Templates/azuredeploy.json
+++ b/AzureFunctionDeployExample/Templates/azuredeploy.json
@@ -48,7 +48,6 @@
             "Example_Custom_AppSetting": "...",
 
             "FUNCTIONS_EXTENSION_VERSION": "~0.6",
-            "AZUREJOBS_EXTENSION_VERSION": "beta",
 
             "AzureWebJobsDashboard": "[variables('storage_connectionstring')",
             "AzureWebJobsStorage": "[variables('storage_connectionstring')"


### PR DESCRIPTION
This setting is no longer needed and should be removed. It could cause issues going forward.